### PR TITLE
Add local assembly minutes downloader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # kumagaya-gikai-ai
+
+このリポジトリには、地方議会の会議録をダウンロードするための簡易スクリプトが含まれています。
+
+## 使い方
+
+```bash
+python download_minutes.py <index_page_url> -o <output_dir>
+```
+
+- `<index_page_url>`: 会議録へのリンクが掲載されているページのURL。
+- `<output_dir>`: ダウンロードしたファイルを保存するディレクトリ。省略時は`minutes`ディレクトリに保存されます。
+
+スクリプトはページ上のPDF/TXT/HTMLファイルへのリンクを解析し、リンク先のファイルを取得して指定ディレクトリに保存します。
+
+## 例
+
+```bash
+python download_minutes.py https://example.com/kaigiroku/index.html -o data
+```
+
+> 実際の自治体サイトを利用する際は、サイト利用規約に従ってください。

--- a/download_minutes.py
+++ b/download_minutes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Simple downloader for local assembly minutes.
+
+This script fetches an index page and downloads files (PDF/TXT/HTML) linked
+from it. It uses only the Python standard library so it can run in restricted
+environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+from urllib.request import urlopen, urlretrieve, URLError
+
+
+class MinutesLinkParser(HTMLParser):
+    """HTML parser that collects links to minutes files."""
+
+    def __init__(self, base_url: str) -> None:
+        super().__init__()
+        self.base_url = base_url
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = dict(attrs).get("href")
+        if not href:
+            return
+        href = href.strip()
+        # Capture common minute file types.
+        if re.search(r"\.(pdf|txt|html?)$", href, re.IGNORECASE):
+            self.links.append(urljoin(self.base_url, href))
+
+
+def download_minutes(index_url: str, output_dir: str) -> list[str]:
+    """Download minutes files linked from *index_url* to *output_dir*.
+
+    Returns a list of file paths that were saved.
+    """
+
+    try:
+        with urlopen(index_url) as resp:
+            html = resp.read().decode("utf-8", errors="ignore")
+    except URLError as exc:
+        raise SystemExit(f"Failed to fetch {index_url}: {exc}")
+
+    parser = MinutesLinkParser(index_url)
+    parser.feed(html)
+
+    os.makedirs(output_dir, exist_ok=True)
+    saved_paths = []
+    for link in parser.links:
+        filename = os.path.basename(urlparse(link).path)
+        if not filename:
+            continue
+        destination = os.path.join(output_dir, filename)
+        try:
+            urlretrieve(link, destination)
+        except URLError as exc:
+            print(f"Failed to download {link}: {exc}")
+            continue
+        print(f"Downloaded {link} -> {destination}")
+        saved_paths.append(destination)
+    return saved_paths
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download local assembly minutes files from an index page"
+    )
+    parser.add_argument(
+        "index_url",
+        help="URL of the page that lists minute files",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="minutes",
+        help="Directory to store downloaded files (default: minutes)",
+    )
+    args = parser.parse_args()
+    download_minutes(args.index_url, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_minutes.py` script to fetch council minute files via standard library
- document usage and example in README

## Testing
- `python -m py_compile download_minutes.py`
- `python download_minutes.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688da53d3d00832d883e673e081d66fd